### PR TITLE
[BUG] The execution when the dataset has a column where all values are the same.

### DIFF
--- a/R/RIT.R
+++ b/R/RIT.R
@@ -20,7 +20,7 @@ RIT <- function(x,y,approx="lpd4",seed=NULL){
 
   if (sd(x)==0 | sd(y)==0){
     out=list(p=1,Sta=0);
-    return(out$p)
+    return(out)
   }
 
   x=matrix2(x);

--- a/R/RIT.R
+++ b/R/RIT.R
@@ -19,7 +19,7 @@
 RIT <- function(x,y,approx="lpd4",seed=NULL){
 
   if (sd(x)==0 | sd(y)==0){
-    out=list(p=1,Sta=0);
+    out=list(p.value=1,Sta=0);
     return(out)
   }
 

--- a/R/RIT.R
+++ b/R/RIT.R
@@ -19,7 +19,7 @@
 RIT <- function(x,y,approx="lpd4",seed=NULL){
 
   if (sd(x)==0 | sd(y)==0){
-    out=list(p=1,Sta=0,w=w,b=b);
+    out=list(p=1,Sta=0,b=b);
     return(out$p)
   }
 

--- a/R/RIT.R
+++ b/R/RIT.R
@@ -19,7 +19,7 @@
 RIT <- function(x,y,approx="lpd4",seed=NULL){
 
   if (sd(x)==0 | sd(y)==0){
-    out=list(p=1,Sta=0,b=b);
+    out=list(p=1,Sta=0);
     return(out$p)
   }
 


### PR DESCRIPTION
# Overview
I found the error, and I fixed with the small changes.
1. delete the waste variables, w and b.
2. return list object. 

# Before/After
## Before
```R
library(RCIT)
RIT(rep(0, time=1000), rnorm(1000))
```
```shell
Error in RIT(rep(0, time = 1000), rnorm(1000)): object 'w' not found
Traceback:

1. RIT(rep(0, time = 1000), rnorm(1000))
```

## After
```R
library(RCIT)
RIT(rep(0, time=1000), rnorm(1000))
```
```shell
$p.value
1
$Sta
0
```

---
I hope you accept my PR. Thank you.
